### PR TITLE
For Slim Image by Alpine and Chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # html2pdf-api
-This container runs a web service that converts Japanese HTML files to PDF using Google Chrome.
+This container runs a web service that converts Japanese HTML files to PDF using Chromium.
 
 ## Usage
 ### Build


### PR DESCRIPTION
ベースイメージをAlpineに変更し,使用するパッケージをChromeから,Chromiumに変更することで,
イメージの軽量化・ビルド時間の短縮・Dockerfileの簡略化を実現されました.

又,不要と思われる操作も整理し削除されました.
Displayに関しては,詳細不明なため残しています.

Debianベースのイメージのままにしたい場合でも,軽量化のためwgetで取得したzipファイルは削除するべきです.